### PR TITLE
revise batch order api doc

### DIFF
--- a/source/includes/_rest_prv_order_cancel.md
+++ b/source/includes/_rest_prv_order_cancel.md
@@ -41,7 +41,7 @@
 
 **HTTP Request**
 
-`POST /<grp>/api/pro/v2/futures/order`
+`DELETE /<grp>/api/pro/v2/futures/order`
 
 **Prehash String**
 

--- a/source/includes/_rest_prv_order_cancel_batch.md
+++ b/source/includes/_rest_prv_order_cancel_batch.md
@@ -1,2 +1,74 @@
 ### Cancel Batch Orders
 
+> Cancel Batch Orders - Request Body
+
+```json
+{
+   "orders":[
+      {
+         "id":"sampleRequestId1",
+         "orderId":"a177c2a8cfe1U0123456789eqntvwWsy",
+         "symbol":"BTC-PERP",
+         "time":1613900544076
+      },
+      {
+         "id":"sampleRequestId2",
+         "orderId":"a177c2a8cfe1U0123456789equestId2",
+         "symbol":"BTC-PERP",
+         "time":1613900544076
+      }
+   ]
+}
+```
+
+> Cancel Batch Orders - Successful ACK Response (Status 200, code 0)
+
+```json
+{
+   "code":0,
+   "data":{
+      "meta":{
+         "action":"batch-cancel-order",
+         "respInst":"ACK"
+      },
+      "orders":[
+         {
+            "id":"sampleRequestId1",
+            "orderId":"a177c2a8cfe1U0123456789eqntvwWsy",
+            "orderType":"",
+            "symbol":"BTC-PERP",
+            "timestamp":1613900544091
+         },
+         {
+            "id":"sampleRequestId2",
+            "orderId":"a177c2a8cfe1U0123456789equestId2",
+            "orderType":"",
+            "symbol":"BTC-PERP",
+            "timestamp":1613900544168
+         }
+      ]
+   }
+}
+```
+
+
+Cancel multiple orders in a batch. If any order(s) fails our basic check, the whole batch request will fail.
+
+You may submit up to 10 orders to cancel at a time. Server will respond with error if you submit more than 10 orders.
+
+**HTTP Request**
+
+`DELETE /<grp>/api/pro/v2/futures/order/batch`
+
+**Prehash String**
+
+`v2/futures/order/batch`
+
+**Request Parameters**
+
+ Name          | Data Type           | Description                
+-------------- | ------------------- | -------------------------- 
+ orders        | List                | List of order items to cancel                   
+please refer to [cancel order](#cancel-order) for order item definition
+
+

--- a/source/includes/_rest_prv_order_new_batch.md
+++ b/source/includes/_rest_prv_order_new_batch.md
@@ -3,26 +3,28 @@
 > Place Batch Orders - Request Body
 
 ```json
-[
-    {
-        "id"        : "sampleRequestId1",
-        "time"      : 1613878579169,
-        "symbol"    : "BTC-PERP",
-        "orderPrice": "34000",
-        "orderQty"  : "0.1",
-        "orderType" : "limit",
-        "side"      : "buy"
-    },
-    {
-        "id"        : "sampleRequestId2",
-        "time"      : 1613878579169,
-        "symbol"    : "BTC-PERP",
-        "orderPrice": "35000",
-        "orderQty"  : "0.2",
-        "orderType" : "limit",
-        "side"      : "buy"
-    }
-]
+{
+    "orders": [
+                {
+                    "id"        : "sampleRequestId1",
+                    "time"      : 1613878579169,
+                    "symbol"    : "BTC-PERP",
+                    "orderPrice": "34000",
+                    "orderQty"  : "0.1",
+                    "orderType" : "limit",
+                    "side"      : "buy"
+                },
+                {
+                    "id"        : "sampleRequestId2",
+                    "time"      : 1613878579169,
+                    "symbol"    : "BTC-PERP",
+                    "orderPrice": "35000",
+                    "orderQty"  : "0.2",
+                    "orderType" : "limit",
+                    "side"      : "buy"
+                }
+              ]
+}
 ```
 
 > Place Batch Orders - Successful ACK Response (Status 200, code 0)
@@ -56,7 +58,7 @@
 ```
 
 
-Place multiple orders in a batch. If some order in the batch failed our basic check, then the whole batch request fail.
+Place multiple orders in a batch. If any order(s) fails our basic check, the whole batch request will fail.
 
 You may submit up to 10 orders at a time. Server will respond with error if you submit more than 10 orders.
 
@@ -66,9 +68,11 @@ You may submit up to 10 orders at a time. Server will respond with error if you 
 
 **Prehash String**
 
-`<timestamp>+v2/futures/order/batch`
+`v2/futures/order/batch`
 
 **Request Parameters**
 
-List of objects.
-
+ Name          | Data Type           | Description                
+-------------- | ------------------- | -------------------------- 
+ orders        | List                | List of order items                    
+please refer to [placing new order](#new-order) for order item definition

--- a/source/includes/_rest_prv_order_query_by_id.md
+++ b/source/includes/_rest_prv_order_query_by_id.md
@@ -1,45 +1,14 @@
 ### Query Order By ID
 
-> Query Order with a single order id - Successful Response (Status 200, code 0)
+> Query Orders By IDs - Request Body
 
 ```json
 {
-    "code"     : 0,
-    "accountId": "sampleFuturesAccountId",
-    "ac"       : "FUTURES",
-    "data": {
-        "ac"                  : "FUTURES",
-        "accountId"           : "sampleFuturesAccountId",
-        "avgFilledPx"         : "0",
-        "cumFee"              : "0",
-        "cumFilledQty"        : "0",
-        "errorCode"           : "",
-        "execInst"            : "NULL_VAL",
-        "fee"                 : "0",
-        "feeAsset"            : "USDT",
-        "lastExecTime"        : 1613877923408,
-        "lastPx"              : "0",
-        "lastQty"             : "0",
-        "orderId"             : "a177c29e4064U0123456789dVeUxlVyA",
-        "orderQty"            : "0.1",
-        "orderType"           : "Limit",
-        "posStopLossPrice"    : "0",
-        "posStopLossTrigger"  : "None",
-        "posTakeProfitPrice"  : "0",
-        "posTakeProfitTrigger": "None",
-        "price"               : "34000",
-        "seqNum"              : 18586710,
-        "side"                : "Buy",
-        "status"              : "New",
-        "stopBy"              : "",
-        "stopPrice"           : "0",
-        "symbol"              : "BTC-PERP",
-        "time"                : 1613877922641
-    }
+   "orderId":"a177c29e4064U0123456789dVeUxlVyA,a177c29e4064U0123456789dVeUxlVyB"
 }
 ```
 
-> Query Order with multiple order ids (or a single order id with an extra comma) - Successful Response (Status 200, code 0)
+> Query Order with multiple order ids - Successful Response (Status 200, code 0)
 
 ```json
 {
@@ -75,6 +44,12 @@
             "stopPrice"           : "0",
             "symbol"              : "BTC-PERP",
             "time"                : 1613877922641
+        },
+{
+            "ac"                  : "FUTURES",
+            "accountId"           : "sampleFuturesAccountId",
+            "orderId"             : "a177c29e4064U0123456789dVeUxlVyB",
+            ...
         }
     ]
 }
@@ -86,13 +61,13 @@
 
 **Prehash String**
 
-`<timestamp>+v2/futures/order/status`
+`v2/futures/order/status`
 
 **Request Parameters**
 
 PARAMETER | TYPE      | REQUIRED | DESCRIPTION
 --------- |---------- | -------- | ---------------
-orderId   | String    | Yes      | a single order id, or multiple order ids separated by ,
+orderId   | String    | Yes      | a single order id, or multiple order ids separated by *,*
 
-The API will respond with a list of objects in the data field. Each object in the list contains information of a single order. There's one exception, if you use only a single orderId, the data field of the API response will be simplified to a single object. If you want the API to respond with a list of only one object in this case, add a comma (`,`) to the orderId.
+The API will respond with a list of objects in the data field. Each object in the list contains information of a single order.
 


### PR DESCRIPTION
1.batch order place/cancel in json(dict) format rather than list
2. order query always return order list no matter multi or single id query 
3. need discuss prehash to be ts+path or path?